### PR TITLE
Set the plant type in BlockCrop to Crop

### DIFF
--- a/src/main/java/com/bluepowermod/blocks/worldgen/BlockCrop.java
+++ b/src/main/java/com/bluepowermod/blocks/worldgen/BlockCrop.java
@@ -324,4 +324,10 @@ public class BlockCrop extends BlockCrops implements IGrowable {
         if (world.getBlock(x, y, z) != this) return super.canBlockStay(world, x, y, z);
         return (world.getBlock(x, y - 1, z) instanceof BlockFarmland) || (world.getBlock(x, y - 1, z) instanceof BlockCrop);
     }
+
+    @Override
+    public EnumPlantType getPlantType(IBlockAccess world, int x, int y, int z)
+    {
+    	return EnumPlantType.Crop;
+    }
 }


### PR DESCRIPTION
Otherwise this is set by default to Plains. This should improve mod compatibility.

I know that Cameron_17 said that your flax couldn't be planted on my (Enhanced Biomes) farmland. This may not completely fix it, I may have to change my farmland so that it extends BlockFarmland, but it is necessary to get it all working.
