### PR TITLE
change "\\" path style to "/"

### DIFF
--- a/src/main/java/com/bluepowermod/part/PartFileSyncer.java
+++ b/src/main/java/com/bluepowermod/part/PartFileSyncer.java
@@ -20,7 +20,7 @@ import java.util.List;
 import com.bluepowermod.BluePower;
 
 public class PartFileSyncer {
-    private static final String PATH = BluePower.proxy.getSavePath() + "\\bluepower\\partIds\\";
+    private static final String PATH = BluePower.proxy.getSavePath() + "/bluepower/partIds/";
 
     private static PartFileSyncer INSTANCE = new PartFileSyncer();
 


### PR DESCRIPTION
Debian Linux Testing amd64, Minecraft 1.7.10, Forge 1208
When \ style is used on Linux (and MacOS X should also work this way) - game creates wrong file in wrong location, filename becomes "1.7.\bluepower\partIds\partIds.txt" - and backslashes here are not directory delimiters, they are correct characters in the filename.
Using "/" should make everything ok.
