### PR TITLE
Update BPEventHandler.java - commented the onChunkLoad -> not highly needed and does crash

### DIFF
--- a/src/main/java/com/bluepowermod/events/BPEventHandler.java
+++ b/src/main/java/com/bluepowermod/events/BPEventHandler.java
@@ -67,7 +67,8 @@ public class BPEventHandler {
             warned = true;
         }
     }
-
+//TODO threadsafe - http://pastebin.com/aWxuTjEm
+/*
     @SubscribeEvent
     public void onChunkLoad(ChunkEvent.Load event) {
         Iterable<TileEntity> list = event.getChunk().chunkTileEntityMap.values();
@@ -81,7 +82,7 @@ public class BPEventHandler {
             BluePower.log.info("Converted " + count + " item stacks to the new parts.");
         }
     }
-
+*/
     @SubscribeEvent
     public void onAnvilEvent(AnvilUpdateEvent event) {
 


### PR DESCRIPTION
Hey,

I commented the onChunkLoad Event as it does cause the host to crash due to concurrent issues:
http://pastebin.com/aWxuTjEm

I'm not sure if you want to fix it directly or if you would prefer bringing out a hot fix build without the event so people can enjoy the latest version of your mod. The source might even be outside of your reach (I'm not a developer) but I think making it thread safe wouldn't be hard.
