### PR TITLE
Fixed Timer arrow not syncing with output

### DIFF
--- a/src/main/java/com/bluepowermod/part/gate/digital/GateTimer.java
+++ b/src/main/java/com/bluepowermod/part/gate/digital/GateTimer.java
@@ -31,8 +31,8 @@ public class GateTimer extends GateSimpleDigital implements IGuiButtonSensitive 
 
     private int time = 40;
     private long start = -1;
-    private boolean needsReset;
     private boolean backRedstone;
+    private boolean needsReset;
 
     private GateComponentPointer p;
     private GateComponentTorch t;
@@ -76,19 +76,17 @@ public class GateTimer extends GateSimpleDigital implements IGuiButtonSensitive 
     @Override
     public void tick() {
 
-        if ((back().getInput() && !front().getOutput()) || (left().getInput() && !left().getOutput())
+        if (((back().getInput()) && !front().getOutput()) || (left().getInput() && !left().getOutput())
                 || (right().getInput() && !right().getOutput())) {
             start = -1;
 
             p.setAngle(0);
             p.setIncrement(0);
 
-            // Still starts to run when adjusting timer while stopped
-            if (needsReset){
-                back().setInput(false);
+            if (needsReset) {
+                back().setInput(backRedstone);
                 needsReset = false;
             }
-
             return;
         }
 
@@ -165,8 +163,9 @@ public class GateTimer extends GateSimpleDigital implements IGuiButtonSensitive 
 
         time = value;
         start = 0;
-        back().setInput(true);
         needsReset = true;
+        backRedstone = back().getInput();
+        back().setInput(true);
         sendUpdatePacket();
     }
 

--- a/src/main/java/com/bluepowermod/part/gate/digital/GateTimer.java
+++ b/src/main/java/com/bluepowermod/part/gate/digital/GateTimer.java
@@ -31,6 +31,8 @@ public class GateTimer extends GateSimpleDigital implements IGuiButtonSensitive 
 
     private int time = 40;
     private long start = -1;
+    private boolean needsReset;
+    private boolean backRedstone;
 
     private GateComponentPointer p;
     private GateComponentTorch t;
@@ -81,7 +83,11 @@ public class GateTimer extends GateSimpleDigital implements IGuiButtonSensitive 
             p.setAngle(0);
             p.setIncrement(0);
 
-            back().setInput(false);
+            // Still starts to run when adjusting timer while stopped
+            if (needsReset){
+                back().setInput(false);
+                needsReset = false;
+            }
 
             return;
         }
@@ -118,6 +124,7 @@ public class GateTimer extends GateSimpleDigital implements IGuiButtonSensitive 
 
         if (start == -1)
             start = curTime;
+
 
         p.setAngle((curTime - start) / (double) time);
         p.setIncrement(1 / (double) time);
@@ -159,6 +166,7 @@ public class GateTimer extends GateSimpleDigital implements IGuiButtonSensitive 
         time = value;
         start = 0;
         back().setInput(true);
+        needsReset = true;
         sendUpdatePacket();
     }
 

--- a/src/main/java/com/bluepowermod/part/gate/digital/GateTimer.java
+++ b/src/main/java/com/bluepowermod/part/gate/digital/GateTimer.java
@@ -7,17 +7,6 @@
  */
 package com.bluepowermod.part.gate.digital;
 
-import java.io.DataInput;
-import java.io.DataOutput;
-import java.io.IOException;
-import java.util.List;
-
-import mcp.mobius.waila.api.SpecialChars;
-import net.minecraft.client.gui.GuiScreen;
-import net.minecraft.client.resources.I18n;
-import net.minecraft.entity.player.EntityPlayer;
-import net.minecraft.nbt.NBTTagCompound;
-
 import com.bluepowermod.api.wire.redstone.RedwireType;
 import com.bluepowermod.client.gui.gate.GuiGateSingleCounter;
 import com.bluepowermod.part.IGuiButtonSensitive;
@@ -25,9 +14,18 @@ import com.bluepowermod.part.gate.component.GateComponentBorder;
 import com.bluepowermod.part.gate.component.GateComponentPointer;
 import com.bluepowermod.part.gate.component.GateComponentTorch;
 import com.bluepowermod.part.gate.component.GateComponentWire;
-
 import cpw.mods.fml.relauncher.Side;
 import cpw.mods.fml.relauncher.SideOnly;
+import mcp.mobius.waila.api.SpecialChars;
+import net.minecraft.client.gui.GuiScreen;
+import net.minecraft.client.resources.I18n;
+import net.minecraft.entity.player.EntityPlayer;
+import net.minecraft.nbt.NBTTagCompound;
+
+import java.io.DataInput;
+import java.io.DataOutput;
+import java.io.IOException;
+import java.util.List;
 
 public class GateTimer extends GateSimpleDigital implements IGuiButtonSensitive {
 
@@ -82,6 +80,8 @@ public class GateTimer extends GateSimpleDigital implements IGuiButtonSensitive 
 
             p.setAngle(0);
             p.setIncrement(0);
+
+            back().setInput(false);
 
             return;
         }
@@ -158,6 +158,7 @@ public class GateTimer extends GateSimpleDigital implements IGuiButtonSensitive 
 
         time = value;
         start = 0;
+        back().setInput(true);
         sendUpdatePacket();
     }
 


### PR DESCRIPTION
Idea based on the fact that a toggle in the back fixes the problem.

Fixes #342 

And before comments start appearing like:
- **"Why didn't you just set the angle of the pointer to 0?"**
  
   Believe me, I tried. Problem is that next tick, the pointer will be reset to where the currTime and start values tell it to go. Therefor only having the problem fixed for 1 tick :/ I also tried by setting the currTime == start and vice versa. No effect.
-  **"This is not clean code"**
  
   It fixes a problem with only **2** lines!
   Edit: 8 lines.
   First commit was broken since it would disable the disabling of the gate.
   Second commit had every situation covered except changing the time while disabled.
   Third commit fixes everything
