### PR TITLE
Add name to loot table injection to avoid NullPointerExceptions

### DIFF
--- a/src/main/java/com/bluepowermod/BluePower.java
+++ b/src/main/java/com/bluepowermod/BluePower.java
@@ -116,7 +116,7 @@ public class BluePower {
     {
         ResourceLocation grass = new ResourceLocation("minecraft", "blocks/tall_grass");
         if (event.getName().equals(grass)){
-                event.getTable().addPool(LootPool.builder().addEntry(TableLootEntry.builder(new ResourceLocation("bluepower", "blocks/tall_grass"))).build());
+                event.getTable().addPool(LootPool.builder().addEntry(TableLootEntry.builder(new ResourceLocation("bluepower", "blocks/tall_grass"))).name("bluepower:inject").build());
         }
     }
 

--- a/src/main/java/com/bluepowermod/BluePower.java
+++ b/src/main/java/com/bluepowermod/BluePower.java
@@ -116,7 +116,7 @@ public class BluePower {
     {
         ResourceLocation grass = new ResourceLocation("minecraft", "blocks/tall_grass");
         if (event.getName().equals(grass)){
-                event.getTable().addPool(LootPool.builder().addEntry(TableLootEntry.builder(new ResourceLocation("bluepower", "blocks/tall_grass"))).name("bluepower:inject").build());
+                event.getTable().addPool(LootPool.builder().addEntry(TableLootEntry.builder(new ResourceLocation("bluepower", "blocks/tall_grass"))).name("bluepower:tall_grass").build());
         }
     }
 


### PR DESCRIPTION
This PR adds a name to your loot table injection to avoid NullPointerExceptions and resulting empty loot table when other mods adding also pools to same loot table.

You can test your version without this fix with other mods that also add pools to tall grass. Example: https://www.curseforge.com/minecraft/mc-mods/ceramic-shears/files
