### PR TITLE
fixed weird grassblock replacement around volcano

### DIFF
--- a/src/main/java/com/bluepowermod/world/WorldGenVolcano.java
+++ b/src/main/java/com/bluepowermod/world/WorldGenVolcano.java
@@ -125,7 +125,7 @@ public class WorldGenVolcano extends Feature<NoneFeatureConfiguration> {
         if (world.isEmptyBlock(new BlockPos(x, y, z)))
             return true;
         Block block = world.getBlockState(new BlockPos(x, y, z)).getBlock();
-        return block instanceof LeavesBlock || block instanceof CactusBlock || block instanceof RotatedPillarBlock || block instanceof GrassBlock
+        return block instanceof LeavesBlock || block instanceof CactusBlock || block instanceof RotatedPillarBlock || block instanceof TallGrassBlock
                 || block instanceof FlowerBlock || block == Blocks.WATER;
     }
 


### PR DESCRIPTION
Noticed this when we were testing this on 1.20, seems like it was because you were checking for instances of GrassBlock instead of TallGrassBlock, or at least I'm guess that's what you were trying to do.
<img width="854" height="480" alt="2026-02-14_23 56 02" src="https://github.com/user-attachments/assets/c09f513c-9404-4d21-b2dc-e8e3c68beae0" />
