### PR TITLE
Made gates less of a pain to place, especially on walls

### DIFF
--- a/src/main/java/com/bluepowermod/block/gates/BlockGateBase.java
+++ b/src/main/java/com/bluepowermod/block/gates/BlockGateBase.java
@@ -100,9 +100,9 @@ public class BlockGateBase extends BlockBase implements SimpleWaterloggedBlock {
     public BlockState rotate(BlockState state, LevelAccessor level, BlockPos pos, Rotation rotation) {
         switch (rotation){
             case NONE -> {}
-            case CLOCKWISE_90 -> state.setValue(ROTATION, rotate(state.getValue(ROTATION),  1));
-            case CLOCKWISE_180 -> state.setValue(ROTATION, rotate(state.getValue(ROTATION), 2));
-            case COUNTERCLOCKWISE_90 -> state.setValue(ROTATION, rotate(state.getValue(ROTATION), 3));
+            case CLOCKWISE_90 -> state = state.setValue(ROTATION, rotate(state.getValue(ROTATION),  1));
+            case CLOCKWISE_180 -> state = state.setValue(ROTATION, rotate(state.getValue(ROTATION), 2));
+            case COUNTERCLOCKWISE_90 -> state = state.setValue(ROTATION, rotate(state.getValue(ROTATION), 3));
         }
         level.setBlock(pos, state, 3);
         return state;

--- a/src/main/java/com/bluepowermod/block/gates/BlockGateBase.java
+++ b/src/main/java/com/bluepowermod/block/gates/BlockGateBase.java
@@ -118,7 +118,7 @@ public class BlockGateBase extends BlockBase implements SimpleWaterloggedBlock {
     public BlockState getStateForPlacement(BlockPlaceContext context) {
         FluidState fluidstate = context.getLevel().getFluidState(context.getClickedPos());
         Direction face = context.getClickedFace();
-        return this.defaultBlockState().setValue(ROTATION, context.getHorizontalDirection().getOpposite().get2DDataValue()).setValue(FACING, face).setValue(WATERLOGGED, fluidstate.getType() == Fluids.WATER);
+        return this.defaultBlockState().setValue(ROTATION, DirectionHelper.getRotationFromContext(context)).setValue(FACING, face).setValue(WATERLOGGED, fluidstate.getType() == Fluids.WATER);
     }
 
     @Override

--- a/src/main/java/com/bluepowermod/helper/DirectionHelper.java
+++ b/src/main/java/com/bluepowermod/helper/DirectionHelper.java
@@ -7,7 +7,11 @@
  */
 package com.bluepowermod.helper;
 
+import net.minecraft.core.BlockPos;
 import net.minecraft.core.Direction;
+import net.minecraft.core.Direction.Axis;
+import net.minecraft.world.item.context.BlockPlaceContext;
+import net.minecraft.world.phys.Vec3;
 
 public class DirectionHelper {
 
@@ -38,5 +42,76 @@ public class DirectionHelper {
                 break;
         }
         return dirs;
+    }
+
+    public static final Direction[][] OUTPUT_TABLE = {
+            {Direction.NORTH, Direction.EAST, Direction.SOUTH, Direction.WEST},
+            {Direction.SOUTH, Direction.EAST, Direction.NORTH, Direction.WEST},
+            {Direction.DOWN, Direction.WEST, Direction.UP, Direction.EAST},
+            {Direction.DOWN, Direction.EAST, Direction.UP, Direction.WEST},
+            {Direction.DOWN, Direction.SOUTH, Direction.UP, Direction.NORTH},
+            {Direction.DOWN, Direction.NORTH, Direction.UP, Direction.SOUTH}
+    };
+
+    public static int getRotationFromContext(BlockPlaceContext context) {
+        // how do we want to orient the block when we place it?
+        // attachment face should be the face that was clicked
+        // what about the rotation?
+
+        // option A: output faces away from player, inverted when sneaking
+        // empirical observations: this is super annoying to get the player in the right standing position,
+        // especially when placing the thing on a wall
+
+        // option B: the orientation depends on which part of the face was clicked, not the player's facing
+        // this gives more control to the player but might be confusing
+        // we may want to render a preview of the placement somehow
+
+        BlockPos placePos = context.getClickedPos();
+        Direction faceOfAdjacentBlock = context.getClickedFace();
+        Direction directionTowardAdjacentBlock = faceOfAdjacentBlock.getOpposite();
+        Vec3 relativeHitVec = context.getClickLocation().subtract(Vec3.atLowerCornerOf(placePos));
+        return getRotationFromContext(placePos, directionTowardAdjacentBlock, relativeHitVec);
+    }
+
+    public static int getRotationFromContext(BlockPos placePos, Direction directionTowardAdjacentBlock, Vec3 relativeHitVec)
+    {
+        Direction outputDirection = getOutputDirectionFromRelativeHitVec(relativeHitVec, directionTowardAdjacentBlock);
+        int rotationIndex = getRotationIndexForDirection(directionTowardAdjacentBlock, outputDirection);
+        return rotationIndex;
+    }
+
+    public static int getRotationIndexForDirection(Direction attachmentFace, Direction outputDirection)
+    {
+        // now using the lookup table above, find the index matching our directions
+        Direction[] rotatedOutputs = OUTPUT_TABLE[attachmentFace.ordinal()];
+        int size = rotatedOutputs.length;
+        for (int i=0; i<size; i++)
+        {
+            if (rotatedOutputs[i] == outputDirection)
+            {
+                return i;
+            }
+        }
+
+        return 0;
+    }
+
+    public static Direction getOutputDirectionFromRelativeHitVec(Vec3 hitVec, Direction directionTowardBlockAttachedTo)
+    {
+        // we have the relative hit vector, where 0,0,0 is the bottom-left corner of the cube we are placing into
+        // and 1,1,1 is the top-right
+        // how do we convert this into a direction?
+        // we want to ignore the attachment direction and its opposite
+        // Direction has a method that converts a vector to a direction
+        // we could "flatten" the hit vec's value on the axis of attachment
+        // Direction::getFacingFromVector uses 0,0,0 as the center and 1,1,1 and -1,-1,-1 as corners,
+        // so we'll want to map our hitvec accordingly
+
+        Axis axis = directionTowardBlockAttachedTo.getAxis();
+        float x = (float) (axis == Axis.X ? 0F : hitVec.x*2 - 1);
+        float y = (float) (axis == Axis.Y ? 0F : hitVec.y*2 - 1);
+        float z = (float) (axis == Axis.Z ? 0F : hitVec.z*2 - 1);
+
+        return Direction.getNearest(x, y, z);
     }
 }


### PR DESCRIPTION
I made it so that when you place a gate it gets rotated based off whatever is the nearest edge on the face that you clicked instead of basing it off the player's rotation
I also fixed the screwdriver not rotating them.
Also I found code I can borrow from more red to do the placement preview thing from 1.7.10, though I'm not going to that yet